### PR TITLE
DDCNL-6041 - Updated dependencies to remove joda time for java time

### DIFF
--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -6,18 +6,18 @@ object AppDependencies {
 
   val compile = Seq(
     ws,
-    "uk.gov.hmrc"   %% "domain"                      % "6.2.0-play-28",
-    "uk.gov.hmrc"   %% "emailaddress"                % "3.5.0",
-    "uk.gov.hmrc"   %% "bootstrap-backend-play-28"   % "5.18.0",
-    "uk.gov.hmrc"   %% "tax-year"                    % "1.2.0"
+    "uk.gov.hmrc"       %% "domain"                    % "8.1.0-play-28",
+    "uk.gov.hmrc"       %% "emailaddress"              % "3.6.0",
+    "uk.gov.hmrc"       %% "bootstrap-backend-play-28" % "5.18.0",
+    "uk.gov.hmrc"       %% "tax-year"                  % "3.0.0"
   )
 
   val test: Seq[ModuleID] = Seq(
-    "org.jsoup"                % "jsoup"               % "1.13.1",
-    "org.scalatestplus.play"  %% "scalatestplus-play"  % "5.1.0",
-    "org.mockito"              % "mockito-core"        % "3.6.0",
-    "com.github.tomakehurst"   % "wiremock-jre8"       % "2.27.0",
-    "com.vladsch.flexmark"     % "flexmark-all"        % "0.35.10"
+    "org.jsoup"                % "jsoup"              % "1.14.3",
+    "org.scalatestplus.play"  %% "scalatestplus-play" % "5.1.0",
+    "org.mockito"              % "mockito-core"       % "4.5.1",
+    "com.github.tomakehurst"   % "wiremock-jre8"      % "2.27.2",
+    "com.vladsch.flexmark"     % "flexmark-all"       % "0.35.10"
   ).map(_ % "test,it")
 
   private val silencerDependencies: Seq[ModuleID] = Seq(


### PR DESCRIPTION
- Any further transient references to joda time will disappear when upgrade to Play 2.9.